### PR TITLE
Support forwarding info about login security level

### DIFF
--- a/flask_multipass/core.py
+++ b/flask_multipass/core.py
@@ -211,6 +211,10 @@ class Multipass(object):
             identity_info = provider.get_identity_from_auth(auth_info.map(mapping))
             if identity_info is None:
                 continue
+            if identity_info.secure_login is None:
+                # if no information about login security has been set by the identity
+                # provider, copy whatever the auth provider may have
+                identity_info.secure_login = auth_info.secure_login
             identities.append(identity_info)
             if not current_app.config['MULTIPASS_ALL_MATCHING_IDENTITIES']:
                 break

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,13 +12,18 @@ try:
 except ImportError:
     from unittest.mock import MagicMock
 
-from flask_multipass import AuthInfo, IdentityInfo
+from flask_multipass import AuthInfo, AuthProvider, IdentityInfo, Multipass
 
 
-def test_authinfo():
+@pytest.fixture(name='dummy_auth_provider')
+def dummy_auth_provider_fixture():
+    return AuthProvider(Multipass(), 'dummy', {})
+
+
+def test_authinfo(dummy_auth_provider):
     with pytest.raises(ValueError):
-        AuthInfo(None)
-    ai = AuthInfo(None, foo='bar')
+        AuthInfo(dummy_auth_provider)
+    ai = AuthInfo(dummy_auth_provider, foo='bar')
     assert ai.data == {'foo': 'bar'}
 
 
@@ -26,16 +31,16 @@ def test_authinfo():
     ({},             {'foo': 'bar', 'meow': 1337}),
     ({'oof': 'foo'}, {'oof': 'bar', 'meow': 1337}),
 ))
-def test_authinfo_map(mapping, output_data):
-    ai = AuthInfo(None, foo='bar', meow=1337)
+def test_authinfo_map(dummy_auth_provider, mapping, output_data):
+    ai = AuthInfo(dummy_auth_provider, foo='bar', meow=1337)
     original_data = ai.data.copy()
     ai2 = ai.map(mapping)
     assert ai2.data == output_data
     assert ai.data == original_data
 
 
-def test_authinfo_map_invalid():
-    ai = AuthInfo(None, foo='bar')
+def test_authinfo_map_invalid(dummy_auth_provider):
+    ai = AuthInfo(dummy_auth_provider, foo='bar')
     with pytest.raises(KeyError):
         ai.map({'foo': 'nop'})
 


### PR DESCRIPTION
This fully depends on what kind of data an auth provider includes, since there is no standard on how to indicate whether a login used 2FA or not.

With CERN accounts using OIDC, a "role" with the 2FA restriction can be created in application management for example, and then it can be checked using a callable like this in the auth provider settings (with `admins-2fa` being the name of the role):

    'is_secure_login': lambda ai: 'admins-2fa' in ai.data.get('cern_roles', [])