### PR TITLE
Python 3 LDAP compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 install:
   - pip install -U pip setuptools
   - '[[ "$DEPS" == "devel" ]] && pip install git+https://github.com/pallets/flask.git || :'
-  - pip install -U pytest pytest-cov pytest-mock pytest-pep8 coveralls
-  - '[[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] && pip install flask-wtf python-ldap || :'
+  - pip install -U pytest pytest-cov pytest-mock pytest-pep8 coveralls python-ldap
+  - '[[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] && pip install flask-wtf || :'
   - pip install -e .
 script:
   - pytest --pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ env:
 install:
   - pip install -U pip setuptools
   - '[[ "$DEPS" == "devel" ]] && pip install git+https://github.com/pallets/flask.git || :'
-  - pip install -U pytest pytest-cov pytest-mock pytest-pep8 coveralls python-ldap
-  - '[[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] && pip install flask-wtf || :'
+  - pip install -U pytest pytest-cov pytest-mock pytest-pep8 coveralls python-ldap flask-wtf
   - pip install -e .
 script:
   - pytest --pep8

--- a/flask_multipass/_compat.py
+++ b/flask_multipass/_compat.py
@@ -8,6 +8,7 @@ import operator
 import sys
 
 if sys.version_info[0] > 2:
+    from urllib.parse import urlparse
     PY2 = False
     bytes_type = bytes
     text_type = str
@@ -20,6 +21,7 @@ if sys.version_info[0] > 2:
     def itervalues(arg, **kwargs):
         return iter(arg.values(**kwargs))
 else:
+    from urlparse import urlparse
     PY2 = True
     bytes_type = str
     text_type = unicode

--- a/flask_multipass/_compat.py
+++ b/flask_multipass/_compat.py
@@ -7,8 +7,9 @@
 import operator
 import sys
 
+from werkzeug.urls import url_parse
+
 if sys.version_info[0] > 2:
-    from urllib.parse import urlparse
     PY2 = False
     bytes_type = bytes
     text_type = str
@@ -21,7 +22,6 @@ if sys.version_info[0] > 2:
     def itervalues(arg, **kwargs):
         return iter(arg.values(**kwargs))
 else:
-    from urlparse import urlparse
     PY2 = True
     bytes_type = str
     text_type = unicode

--- a/flask_multipass/_compat.py
+++ b/flask_multipass/_compat.py
@@ -7,7 +7,6 @@
 import operator
 import sys
 
-from werkzeug.urls import url_parse
 
 if sys.version_info[0] > 2:
     PY2 = False

--- a/flask_multipass/providers/ldap/operations.py
+++ b/flask_multipass/providers/ldap/operations.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 from ldap import NO_SUCH_OBJECT, SCOPE_BASE, SCOPE_SUBTREE
 from ldap.controls import SimplePagedResultsControl
 
-from flask_multipass._compat import text_type
 from flask_multipass.exceptions import GroupRetrievalFailed, IdentityRetrievalFailed
 from flask_multipass.providers.ldap.globals import current_ldap
 from flask_multipass.providers.ldap.util import build_search_filter, find_one, get_page_cookie
@@ -90,8 +89,6 @@ def search(base_dn, search_filter, attributes):
     """
     connection, settings = current_ldap
     page_ctrl = SimplePagedResultsControl(True, size=settings['page_size'], cookie='')
-    if isinstance(search_filter, text_type):
-        search_filter = search_filter.encode('utf-8')
 
     while True:
         msg_id = connection.search_ext(base_dn, SCOPE_SUBTREE, filterstr=search_filter, attrlist=attributes,

--- a/flask_multipass/providers/ldap/operations.py
+++ b/flask_multipass/providers/ldap/operations.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 from ldap import NO_SUCH_OBJECT, SCOPE_BASE, SCOPE_SUBTREE
 from ldap.controls import SimplePagedResultsControl
 
+from flask_multipass._compat import text_type
 from flask_multipass.exceptions import GroupRetrievalFailed, IdentityRetrievalFailed
 from flask_multipass.providers.ldap.globals import current_ldap
 from flask_multipass.providers.ldap.util import build_search_filter, find_one, get_page_cookie
@@ -89,7 +90,7 @@ def search(base_dn, search_filter, attributes):
     """
     connection, settings = current_ldap
     page_ctrl = SimplePagedResultsControl(True, size=settings['page_size'], cookie='')
-    if isinstance(search_filter, unicode):
+    if isinstance(search_filter, text_type):
         search_filter = search_filter.encode('utf-8')
 
     while True:

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -122,7 +122,10 @@ class LDAPGroup(Group):
                                        **to_unicode(user_data))
                 group_filter = build_group_search_filter({self.ldap_settings['member_of_attr']: {group_dn}}, exact=True)
                 subgroups = list(self.provider._search_groups(group_filter))
-                group_dn = group_dns.send(subgroups)
+                try:
+                    group_dn = group_dns.send(subgroups)
+                except StopIteration:
+                    return
 
     def has_member(self, user_identifier):
         with ldap_context(self.ldap_settings):

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -12,7 +12,7 @@ from ldap import INVALID_CREDENTIALS
 from wtforms.fields import StringField, PasswordField
 from wtforms.validators import DataRequired
 
-from flask_multipass._compat import FlaskForm
+from flask_multipass._compat import FlaskForm, PY2
 from flask_multipass.auth import AuthProvider
 from flask_multipass.data import AuthInfo, IdentityInfo
 from flask_multipass.exceptions import NoSuchUser, InvalidCredentials, IdentityRetrievalFailed, GroupRetrievalFailed
@@ -53,7 +53,8 @@ class LDAPProviderMixin(object):
         if not self.ldap_settings['cert_file'] and self.ldap_settings['verify_cert']:
             warn("You should install certifi or provide a certificate file in order to verify the LDAP certificate.")
         # Convert LDAP settings to bytes since python-ldap chokes on unicode strings
-        self.settings['ldap'] = to_bytes_recursive(self.settings['ldap'])
+        if PY2:
+            self.settings['ldap'] = to_bytes_recursive(self.settings['ldap'])
 
 
 class LDAPAuthProvider(LDAPProviderMixin, AuthProvider):
@@ -152,10 +153,10 @@ class LDAPIdentityProvider(LDAPProviderMixin, IdentityProvider):
     def __init__(self, *args, **kwargs):
         super(LDAPIdentityProvider, self).__init__(*args, **kwargs)
         self.set_defaults()
-        self.ldap_settings.setdefault(b'gid', b'cn')
-        self.ldap_settings.setdefault(b'group_filter', b'(objectClass=groupOfNames)')
-        self.ldap_settings.setdefault(b'member_of_attr', b'memberOf')
-        self.ldap_settings.setdefault(b'ad_group_style', False)
+        self.ldap_settings.setdefault('gid', 'cn')
+        self.ldap_settings.setdefault('group_filter', '(objectClass=groupOfNames)')
+        self.ldap_settings.setdefault('member_of_attr', 'memberOf')
+        self.ldap_settings.setdefault('ad_group_style', False)
         self.settings['mapping'] = to_bytes_recursive(self.settings['mapping'])
         self._attributes = list(
             convert_app_data(self.settings['mapping'], {}, self.settings['identity_info_keys']).values())

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -125,7 +125,7 @@ class LDAPGroup(Group):
                 try:
                     group_dn = group_dns.send(subgroups)
                 except StopIteration:
-                    return
+                    break
 
     def has_member(self, user_identifier):
         with ldap_context(self.ldap_settings):

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -157,7 +157,8 @@ class LDAPIdentityProvider(LDAPProviderMixin, IdentityProvider):
         self.ldap_settings.setdefault(b'member_of_attr', b'memberOf')
         self.ldap_settings.setdefault(b'ad_group_style', False)
         self.settings['mapping'] = to_bytes_recursive(self.settings['mapping'])
-        self._attributes = convert_app_data(self.settings['mapping'], {}, self.settings['identity_info_keys']).values()
+        self._attributes = list(
+            convert_app_data(self.settings['mapping'], {}, self.settings['identity_info_keys']).values())
         self._attributes.append(self.ldap_settings['uid'])
 
     @property

--- a/flask_multipass/providers/ldap/util.py
+++ b/flask_multipass/providers/ldap/util.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 
 from collections import namedtuple
 from contextlib import contextmanager
-from urlparse import urlparse
 from warnings import warn
 
 import ldap
@@ -17,7 +16,7 @@ from ldap.controls import SimplePagedResultsControl
 from ldap.filter import filter_format
 from ldap.ldapobject import ReconnectLDAPObject
 
-from flask_multipass._compat import iteritems, itervalues, text_type
+from flask_multipass._compat import iteritems, itervalues, text_type, urlparse
 from flask_multipass.exceptions import MultipassException
 from flask_multipass.providers.ldap.exceptions import LDAPServerError
 from flask_multipass.providers.ldap.globals import _ldap_ctx_stack, current_ldap

--- a/flask_multipass/providers/ldap/util.py
+++ b/flask_multipass/providers/ldap/util.py
@@ -226,14 +226,14 @@ def to_unicode(data):
 
 def to_bytes_recursive(obj):
     if isinstance(obj, dict):
-        return dict((bytes(k), to_bytes_recursive(v)) for k, v in iteritems(obj))
+        return {to_bytes_recursive(k): to_bytes_recursive(v) for k, v in iteritems(obj)}
     elif isinstance(obj, list):
-        return map(to_bytes_recursive, obj)
+        return [to_bytes_recursive(x) for x in obj]
     elif isinstance(obj, set):
         return {to_bytes_recursive(x) for x in obj}
     elif isinstance(obj, tuple):
         return tuple(to_bytes_recursive(x) for x in obj)
-    elif isinstance(obj, unicode):
-        return bytes(obj)
+    elif isinstance(obj, text_type):
+        return obj.encode('utf-8')
     else:
         return obj

--- a/flask_multipass/providers/ldap/util.py
+++ b/flask_multipass/providers/ldap/util.py
@@ -221,7 +221,12 @@ def get_page_cookie(server_ctrls):
 
 
 def to_unicode(data):
-    return {text_type(k): [x.decode('utf-8', 'replace') for x in v] for k, v in iteritems(data)}
+    if isinstance(data, text_type):
+        return data
+    elif isinstance(data, bytes):
+        return data.decode('utf-8', 'replace')
+    else:
+        return {text_type(k): [to_unicode(x) for x in v] for k, v in iteritems(data)}
 
 
 def to_bytes_recursive(obj):

--- a/flask_multipass/providers/ldap/util.py
+++ b/flask_multipass/providers/ldap/util.py
@@ -16,7 +16,7 @@ from ldap.controls import SimplePagedResultsControl
 from ldap.filter import filter_format
 from ldap.ldapobject import ReconnectLDAPObject
 
-from flask_multipass._compat import iteritems, itervalues, text_type, urlparse
+from flask_multipass._compat import iteritems, itervalues, text_type, url_parse
 from flask_multipass.exceptions import MultipassException
 from flask_multipass.providers.ldap.exceptions import LDAPServerError
 from flask_multipass.providers.ldap.globals import _ldap_ctx_stack, current_ldap
@@ -130,7 +130,7 @@ def ldap_connect(settings, use_cache=True):
         if conn is not None:
             return conn
 
-    uri_info = urlparse(settings['uri'])
+    uri_info = url_parse(settings['uri'])
     use_ldaps = uri_info.scheme == 'ldaps'
     credentials = (settings['bind_dn'], settings['bind_password'])
     ldap_connection = ReconnectLDAPObject(settings['uri'])

--- a/flask_multipass/providers/ldap/util.py
+++ b/flask_multipass/providers/ldap/util.py
@@ -15,8 +15,9 @@ from flask import appcontext_tearing_down, g, has_app_context, current_app
 from ldap.controls import SimplePagedResultsControl
 from ldap.filter import filter_format
 from ldap.ldapobject import ReconnectLDAPObject
+from werkzeug.urls import url_parse
 
-from flask_multipass._compat import iteritems, itervalues, text_type, url_parse
+from flask_multipass._compat import iteritems, itervalues, text_type
 from flask_multipass.exceptions import MultipassException
 from flask_multipass.providers.ldap.exceptions import LDAPServerError
 from flask_multipass.providers.ldap.globals import _ldap_ctx_stack, current_ldap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,3 @@ def pytest_configure(config):
     attrs = ('AuthProvider', 'Group', 'IdentityProvider')
     for attr in attrs:
         getattr(flask_multipass, attr).__support_attrs__ = {}
-
-
-collect_ignore = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,5 +19,3 @@ def pytest_configure(config):
 
 
 collect_ignore = []
-if sys.version_info[0] > 2:
-    collect_ignore.append('providers/ldap/')

--- a/tests/providers/ldap/test_operations.py
+++ b/tests/providers/ldap/test_operations.py
@@ -23,13 +23,13 @@ from flask_multipass.providers.ldap.util import ldap_context
 def test_get_user_by_id_handles_none_id():
     with pytest.raises(IdentityRetrievalFailed) as excinfo:
         get_user_by_id(None)
-    assert excinfo.value.message == 'No identifier specified'
+    assert str(excinfo.value) == 'No identifier specified'
 
 
 def test_get_group_by_id_handles_none_id():
     with pytest.raises(GroupRetrievalFailed) as excinfo:
         get_group_by_id(None)
-    assert excinfo.value.message == 'No identifier specified'
+    assert str(excinfo.value) == 'No identifier specified'
 
 
 @pytest.mark.parametrize(('settings', 'base_dn', 'search_filter', 'attributes', 'mock_data', 'expected'), (

--- a/tests/providers/ldap/test_util.py
+++ b/tests/providers/ldap/test_util.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from unittest.mock import call, MagicMock
 
-from flask_multipass._compat import urlparse
+from flask_multipass._compat import url_parse
 from flask_multipass.exceptions import MultipassException
 from flask_multipass.util import convert_app_data
 from flask_multipass.providers.ldap.globals import current_ldap
@@ -152,7 +152,7 @@ def test_ldap_context(mocker, settings, options):
         assert ldap_conn.protocol_version == ldap.VERSION3, 'LDAP v3 has not been set'
         assert ldap_conn.set_option.mock_calls == [call.set_option(*args) for args in options], 'Not all options set'
         if settings['starttls']:
-            if urlparse(settings['uri']).scheme == 'ldaps':
+            if url_parse(settings['uri']).scheme == 'ldaps':
                 warn.assert_called_once_with('Unable to start TLS, LDAP connection already secured over SSL (LDAPS)')
             else:
                 ldap_conn.start_tls_s.assert_called_once_with()

--- a/tests/providers/ldap/test_util.py
+++ b/tests/providers/ldap/test_util.py
@@ -192,7 +192,7 @@ def test_ldap_context_invalid_credentials(mocker, method, triggered_exception, c
     with pytest.raises(caught_exception) as excinfo:
         with ldap_context(settings):
             current_ldap.connection.search_s('dc=example,dc=com', ldap.SCOPE_SUBTREE)
-    assert excinfo.value.message == message
+    assert str(excinfo.value) == message
 
 
 @pytest.mark.parametrize(('base_dn', 'search_filter', 'data', 'expected'), (

--- a/tests/providers/ldap/test_util.py
+++ b/tests/providers/ldap/test_util.py
@@ -7,7 +7,6 @@
 from __future__ import unicode_literals
 
 from collections import OrderedDict
-from urlparse import urlparse
 
 import ldap
 import pytest
@@ -17,6 +16,7 @@ try:
 except ImportError:
     from unittest.mock import call, MagicMock
 
+from flask_multipass._compat import urlparse
 from flask_multipass.exceptions import MultipassException
 from flask_multipass.util import convert_app_data
 from flask_multipass.providers.ldap.globals import current_ldap

--- a/tests/providers/ldap/test_util.py
+++ b/tests/providers/ldap/test_util.py
@@ -10,13 +10,13 @@ from collections import OrderedDict
 
 import ldap
 import pytest
+from werkzeug.urls import url_parse
 
 try:
     from mock import call, MagicMock
 except ImportError:
     from unittest.mock import call, MagicMock
 
-from flask_multipass._compat import url_parse
 from flask_multipass.exceptions import MultipassException
 from flask_multipass.util import convert_app_data
 from flask_multipass.providers.ldap.globals import current_ldap

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest-cov
     pytest-mock
     mock
-    py27: python-ldap
+    python-ldap
     release: flask
     devel: git+https://github.com/pallets/flask.git
     flask-wtf


### PR DESCRIPTION
Closes #6 following the approach in [this comment](https://github.com/indico/flask-multipass/issues/6#issuecomment-550231418). 

## Changes

* Update the test suite to install the LDAP dependency on python 3 and run the LDAP tests.
* Consistently use `_compat.py` and add a `_compat.urlparse` import.
* Only convert the `ldap_settings` dictionary to bytes on Python 2. I didn't see anything about this being required in the `python-ldap` docs, so this may not even be required on Python 2.
* Miscellaneous compatibility changes required by the test suite.

## Testing

I'm not very familiar with Flask, and do not have an LDAP endpoint I can test this against. For that reason, I relied exclusively on the test suite, which passes locally on Python 2.7 and 3.7. 