### PR TITLE
Fix LDAP filtering with binary values

### DIFF
--- a/flask_multipass/__init__.py
+++ b/flask_multipass/__init__.py
@@ -12,7 +12,7 @@ from .exceptions import (MultipassException, AuthenticationFailed, IdentityRetri
 from .group import Group
 from .identity import IdentityProvider
 
-__version__ = '0.3-dev3'
+__version__ = '0.3-dev4'
 __all__ = ('Multipass', 'AuthProvider', 'IdentityProvider', 'AuthInfo', 'IdentityInfo', 'Group', 'MultipassException',
            'AuthenticationFailed', 'IdentityRetrievalFailed', 'GroupRetrievalFailed', 'NoSuchUser',
            'InvalidCredentials')

--- a/flask_multipass/providers/oidc.py
+++ b/flask_multipass/providers/oidc.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 
 import requests
 from authlib.common.errors import AuthlibBaseError
-from authlib.common.security import generate_token
 from authlib.integrations.flask_client import RemoteApp
 from authlib.integrations.requests_client import OAuth1Session, OAuth2Session
 from authlib.jose import jwk, jwt

--- a/tests/providers/ldap/test_util.py
+++ b/tests/providers/ldap/test_util.py
@@ -26,6 +26,7 @@ from flask_multipass.providers.ldap.util import build_search_filter, find_one, l
 @pytest.mark.parametrize(('criteria', 'type_filter', 'mapping', 'exact', 'expected'), (
     ({}, '', None, True, None),
     ({}, '', '(|(objectClass=Person)(objectCategory=user))', True, None),
+    ({'cn': ['foobar'], 'objectSid': [b'\00\xa0foo']}, '', None, True, r"(&(cn=foobar)(objectSid=\00\a0\66\6f\6f))"),
     ({'givenName': ['Alain'], 'sn': ["D'Issoir"]}, '', None, True, "(&(givenName=Alain)(sn=D'Issoir))"),
     ({'givenName': ['Alain'], 'last_name': ["D'Issoir"]}, '', {'last_name': 'sn'}, True,
      "(&(givenName=Alain)(sn=D'Issoir))"),


### PR DESCRIPTION
This is needed e.g. when getting someone's group list which requires filtering by the binary objectSid attribute.