### PR TITLE
Shibboleth auth provider: return an identifier if identifier_field params is defined

### DIFF
--- a/flask_multipass/providers/shibboleth.py
+++ b/flask_multipass/providers/shibboleth.py
@@ -67,7 +67,14 @@ class ShibbolethAuthProvider(AuthProvider):
 
         if not attributes:
             raise AuthenticationFailed("No valid data received", provider=self)
-        return self.multipass.handle_auth_success(AuthInfo(self, **attributes))
+
+        # Define 'identifier' attribute if 'identifier_field' is defined.
+        # Required to use a LDAP identity provider with the SSO auth provider.
+        identifier_field = self.settings.get('identifier_field')
+        if identifier_field:
+            return self.multipass.handle_auth_success(AuthInfo(self, identifier=attributes[identifier_field], **attributes))
+        else:
+            return self.multipass.handle_auth_success(AuthInfo(self, **attributes))
 
 
 class ShibbolethIdentityProvider(IdentityProvider):


### PR DESCRIPTION
The [Indico documentation](https://docs.getindico.io/en/latest/config/auth/#saml-shibboleth) suggests that it is a good idea to use an LDAP identity provider, when you have one like AD, with a Shibboleth auth provider, to benefit from the group definitions coming from LDAP. Unfortunately it doesn't work because the LDAP identity provider is expecting the auth provider to return an `identifier` attribute in the  `AuthInfo` object (as does the LDAP auth provider) but the Shibboleth auth provider doesn't.

This PR proposes to use the `identifier_field` parameter, normally used by identity providers, in the Shibboleth auth provider params as an indication that the `AuthInfo` `identifier` attribute must be defined (with the Shibboleth attributed defined by the value of `identifier_field`). If this parameter is undefined, the behaviour of the Shibboleth auth provider is unchanged.

This PR has been tested successfully at IJCLab. Note that the limitation is that every user authenticated through Shibboleth must has a matching account in LDAP (AD in our case). Supporting authentication for local and remote users through Shibboleth (eduGAIN for example) and using LDAP as the identity provider requires a modification of the LDAP provider (or a custom one) to build the identity from `AuthInfo` attributes provided by Shibboleth when there is no LDAP match...
