### PR TITLE
LDAP identity provider: fix support of an associated Shibboleth auth provider

### DIFF
--- a/flask_multipass/providers/ldap/__init__.py
+++ b/flask_multipass/providers/ldap/__init__.py
@@ -4,7 +4,7 @@
 # Flask-Multipass is free software; you can redistribute it
 # and/or modify it under the terms of the Revised BSD License.
 
-from .providers import LDAPAuthProvider, LDAPGroup, LDAPIdentityProvider
+from .providers import LDAPAuthProvider, LDAPGroup, LDAPIdentityProvider, AuthFallbackLDAPIdentityProvider
 
 
-__all__ = ('LDAPAuthProvider', 'LDAPGroup', 'LDAPIdentityProvider')
+__all__ = ('LDAPAuthProvider', 'LDAPGroup', 'LDAPIdentityProvider', 'AuthFallbackLDAPIdentityProvider')

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -235,14 +235,16 @@ class LDAPIdentityProvider(LDAPProviderMixin, IdentityProvider):
 
 
 class AuthFallbackLDAPIdentityProvider(LDAPIdentityProvider):
-    """Provides identity information using LDAP with a fallback to authorization data.
-
-    This identity provider is meant to be used together with the auth providers, like
-    Shibboleth, who can authorize access to users who are not present is the LDAP directory.
-    By default it will use the identifier returned by the auth provider and lookup all the data 
-    in LDAP.
-
-    In case the user does not have data in LDAP, the data provided via auth provider will be used.
+    """Provides identity information using LDAP with a fallback to auth provider data.
+    
+    This identity provider is meant to be used together with an auth provider that provides
+    all the required data (in particular the Shibboleth provider).
+    
+    By default it will use only the identifier from the auth provider and look up all the data
+    from LDAP.
+    
+    In case the user does not have data in LDAP however, the data provided from the auth provider
+    will be used.
     """
 
     def get_identity_from_auth(self, auth_info):

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -236,13 +236,13 @@ class LDAPIdentityProvider(LDAPProviderMixin, IdentityProvider):
 
 class AuthFallbackLDAPIdentityProvider(LDAPIdentityProvider):
     """Provides identity information using LDAP with a fallback to auth provider data.
-    
+
     This identity provider is meant to be used together with an auth provider that provides
     all the required data (in particular the Shibboleth provider).
-    
+
     By default it will use only the identifier from the auth provider and look up all the data
     from LDAP.
-    
+
     In case the user does not have data in LDAP however, the data provided from the auth provider
     will be used.
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ flask_multipass.auth_providers =
     static = flask_multipass.providers.static:StaticAuthProvider
 flask_multipass.identity_providers =
     ldap = flask_multipass.providers.ldap:LDAPIdentityProvider
+    ldap_or_authinfo = flask_multipass.providers.ldap:AuthFallbackLDAPIdentityProvider
     authlib = flask_multipass.providers.authlib:AuthlibIdentityProvider
     saml = flask_multipass.providers.saml:SAMLIdentityProvider
     shibboleth = flask_multipass.providers.shibboleth:ShibbolethIdentityProvider


### PR DESCRIPTION
The [Indico documentation](https://docs.getindico.io/en/latest/config/auth/#saml-shibboleth) suggests that it is a good idea to use an LDAP identity provider, when you have one like AD, with a Shibboleth auth provider, to benefit from the group definitions coming from LDAP. The problem is that the LDAP identity provider requires the user to exist in LDAP to create its identity, something that is not true if remote users are authenticated through Shibboleth (e.g. eduGAIN).

The original approach to fixe the issue was by addding a new identity provider boolean configuration parameter, `auth_data_if_identifier_missing`: if `True`, create the identity from the `AuthInfo` object (returned by the Shibboleth auth provider) if the user is not found in LDAP. When `False`, the identity provider behaviour is unchanged. After some discussion it was decided to implement basically the same code as a variant of the LDAP identity provider that fallbacks to `AuthInfo` contents if the identifier cannot be retrieved from LDAP.

**Note: for this configuration to work, it is also necessary to define the attribute to use to build the identifier, adding an entry in `PROVIDER_MAP` that defines it, with something like:`

```
# shib-sso is the Shibboleth auth provider, ldap is the LDAP identity provider
'shib-sso': {'identity_provider': 'ldap', 'mapping': {'identifier': 'mail'}}
```
This PR has been tested successfully at IJCLab.
