### PR TITLE
Add support for native SAML (without Shibboleth)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ There are bult-in authentication and identity providers for:
  * `Static (hardcoded) credentials <https://github.com/indico/flask-multipass/blob/master/flask_multipass/providers/static.py>`_
  * `Local (SQLAlchemy DB) authentication <https://github.com/indico/flask-multipass/blob/master/flask_multipass/providers/sqlalchemy.py>`_
  * `Authlib (OAuth/OIDC) <https://github.com/indico/flask-multipass/blob/master/flask_multipass/providers/authlib.py>`_
+ * `SAML <https://github.com/indico/flask-multipass/blob/master/flask_multipass/providers/saml.py>`_
  * `Shibboleth <https://github.com/indico/flask-multipass/blob/master/flask_multipass/providers/shibboleth.py>`_
  * `LDAP <https://github.com/indico/flask-multipass/blob/master/flask_multipass/providers/ldap/providers.py>`_
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,8 @@ Authentication Providers
    :members:
 .. autoclass:: flask_multipass.providers.authlib.AuthlibAuthProvider
    :members:
+.. autoclass:: flask_multipass.providers.saml.SAMLAuthProvider
+   :members:
 .. autoclass:: flask_multipass.providers.static.StaticAuthProvider
    :members:
 .. autoclass:: flask_multipass.providers.shibboleth.ShibbolethAuthProvider
@@ -33,6 +35,8 @@ Identity Providers
 .. autoclass:: flask_multipass.providers.ldap.LDAPIdentityProvider
    :members:
 .. autoclass:: flask_multipass.providers.authlib.AuthlibIdentityProvider
+   :members:
+.. autoclass:: flask_multipass.providers.saml.SAMLIdentityProvider
    :members:
 .. autoclass:: flask_multipass.providers.static.StaticIdentityProvider
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,8 @@ from unittest.mock import MagicMock
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('_themes'))
 
-# Mock away ldap
-for module in ('ldap', 'ldap.controls', 'ldap.filter', 'ldap.ldapobject', 'urlparse'):
+# Mock away ldap/saml
+for module in ('ldap', 'ldap.controls', 'ldap.filter', 'ldap.ldapobject', 'urlparse', 'onelogin.saml2.auth'):
     sys.modules[module] = MagicMock()
 
 # -- General configuration ------------------------------------------------

--- a/docs/config_example.rst
+++ b/docs/config_example.rst
@@ -4,7 +4,7 @@
 Configuration example
 =====================
 
-This configuration can be added to your Flask configuration file that you use when initializing flask application. However, you can configure Multipass also directly through application object for example:
+This configuration can be added to your Flask configuration file that you use when initializing flask application. However, you can configure Multipass also directly through the application object, for example:
 
 .. code-block:: python
 
@@ -14,18 +14,19 @@ Here you can see an example configuration for an application using both external
 
 ``'test_auth_provider'`` is a dummy example of a local authentication provider, it's linked to the ``'test_identity_provider'`` as specified in ``MULTIPASS_PROVIDER_MAP``. You can read more about the configuration of local providers here: :ref:`local_providers`
 
-``'github'``, ``'my_shibboleth'`` and ``'my-ldap'`` are examples of external providers. More on configuration of external providers:  :ref:`external_providers`
+``'github'``, ``'shib'``, ``'saml'`` and ``'my-ldap'`` are examples of external providers. More on configuration of external providers:  :ref:`external_providers`
 
 .. code-block:: python
 
     _github_oauth_config = {
         'client_id': '',  # put your client id here
         'client_secret': '',  # put your client secret here
-        'client_kwargs': {'scope': 'user:email'},
         'authorize_url': 'https://github.com/login/oauth/authorize',
         'access_token_url': 'https://github.com/login/oauth/access_token',
-        'userinfo_endpoint': 'https://api.github.com/user',
+        'api_base_url': 'https://api.github.com',
+        'userinfo_endpoint': '/user',
     }
+
 
     _my_ldap_config = {
         'uri': 'ldaps://ldap.example.com:636',
@@ -49,6 +50,88 @@ Here you can see an example configuration for an application using both external
         'ad_group_style': False,
     }
 
+    _my_saml_config = {
+        # If enabled, errors are more verbose and received attributes are
+        # printed to stdout
+        # 'debug': True,
+        'sp': {
+            # this needs to match what you use when registering the SAML SP
+            'entityId': 'multipass-saml-test',
+            # these bindings usually do not need to be set manually; the URLs
+            # are auto-generated
+            # 'assertionConsumerService': {'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'},
+            # 'singleLogoutService': {'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'},
+            # depending on your security config you may need to generate a
+            # certificate and private key.
+            # you can use https://www.samltool.com/self_signed_certs.php or
+            # use `openssl` for it (which is more secure as it ensures the
+            # key never leaves your machine)
+            'x509cert': '',
+            'privateKey': '',
+            # persistent name ids are the default, but you can override it
+            # with a custom format
+            # 'NameIDFormat': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+        },
+        'idp': {
+            # This metadata is provider by your SAML IdP. You can omit (or
+            # leave empty) the whole 'idp' section in case you need SP
+            # metadata to register your app and get the IdP metadata from
+            # https://yourapp.example.com/multipass/saml/{auth-provider-name}/metadata
+            # and then fill in the IdP metadata afterwards.
+            'entityId': 'https://idp.example.com',
+            'x509cert': '',
+            'singleSignOnService': {
+                'url': 'https://idp.example.com/saml',
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+            },
+            # If you do not want to perform a SAML logout when logging out
+            # from your application, you can omit this section
+            'singleLogoutService': {
+                'url': 'https://idp.example.com/saml',
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+            }
+        },
+        # These advanced settings allow you to tune the SAML security options.
+        # Please see the documentation on https://github.com/onelogin/python3-saml
+        # for details on how they behave. Note that by requiring signatures,
+        # you usually need to set a cert and key on your SP config, but for
+        # testing you may want to disable all signing-related options.
+        'security': {
+            'nameIdEncrypted': False,
+            'authnRequestsSigned': True,
+            'logoutRequestSigned': True,
+            'logoutResponseSigned': True,
+            'signMetadata': True,
+            'wantMessagesSigned': True,
+            'wantAssertionsSigned': True,
+            'wantNameId' : True,
+            'wantNameIdEncrypted': False,
+            'wantAssertionsEncrypted': False,
+            'allowSingleLabelDomains': False,
+            'signatureAlgorithm': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+            'digestAlgorithm': 'http://www.w3.org/2001/04/xmlenc#sha256'
+        },
+        # You can set contact information which will be included in the SP
+        # metadata; it is up to the IdP if/how this information is used:
+        # 'contactPerson': {
+        #     'technical': {
+        #         'givenName': 'technical_name',
+        #         'emailAddress': 'technical@example.com'
+        #     },
+        #     'support': {
+        #         'givenName': 'support_name',
+        #         'emailAddress': 'support@example.com'
+        #     }
+        # },
+        # 'organization': {
+        #     'en-US': {
+        #         'name': 'sp_test',
+        #         'displayname': 'SP test',
+        #         'url': 'http://sp.example.com'
+        #     }
+        # }
+    }
+
     MULTIPASS_AUTH_PROVIDERS = {
         'test_auth_provider': {
             'type': 'static',
@@ -61,24 +144,27 @@ Here you can see an example configuration for an application using both external
         'github': {
             'type': 'authlib',
             'title': 'GitHub',
-            'oauth': _github_oauth_config
+            'authlib_args': _github_oauth_config
         },
         'my-ldap': {
             'type': 'ldap',
             'title': 'My Organization LDAP',
             'ldap': _my_ldap_config,
         },
-        'sso': {
+        'shib': {
             'type': 'shibboleth',
-            'title': 'SSO',
+            'title': 'Shibboleth SSO',
             'callback_uri': '/shibboleth/sso',
-            'logout_uri': 'https://sso.example.com/logout',
-            # optional: defaults to 'ADFS_'
-            'attrs_prefix': 'ADFS_',
-            # optional: if True, gets the fields from the request headers instead,
-            # defaults to False
-            'use_headers': False
-        }
+            'logout_uri': 'https://sso.example.com/logout'
+        },
+        'saml': {
+            'type': 'saml',
+            'title': 'SAML SSO',
+            'saml_config': _my_saml_config,
+            # If your IdP is ADFS you may need to enable this. For details, see
+            # https://github.com/onelogin/python-saml/pull/144
+            # 'lowercase_urlencoding': True
+        },
     }
 
     MULTIPASS_IDENTITY_PROVIDERS = {
@@ -95,10 +181,11 @@ Here you can see an example configuration for an application using both external
         },
         'github': {
             'type': 'authlib',
+            'title': 'GitHub',
             'identifier_field': 'id',
             'mapping': {
-                'user_name': 'login',
-                'affiliation': 'company'
+                'affiliation': 'company',
+                'first_name': 'name'
             }
         },
         'my-ldap': {
@@ -117,13 +204,27 @@ Here you can see an example configuration for an application using both external
                 'name': 'ADFS_FIRSTNAME',
                 'affiliation': 'ADFS_HOMEINSTITUTE'
             }
+        },
+        'saml': {
+            'type': 'saml',
+            'title': 'SAML',
+            'mapping': {
+                'name': 'DisplayName',
+                'email': 'EmailAddress',
+                'affiliation': 'HomeInstitute',
+            },
+            # You can use a different field as the unique identifier.
+            # By default the qualified NameID from SAML is used, but in
+            # case you want to use something else, any SAML attribute can
+            # be used.
+            # 'identifier_field': 'Username'
         }
     }
 
     MULTIPASS_PROVIDER_MAP = {
         'test_auth_provider': 'test_identity_provider',
         'my-ldap': 'my-ldap',
-        'my_shibboleth': 'my_shibboleth',
+        'shib': 'my_shibboleth',
         # You can also be explicit (only needed for more complex links)
         'github': [
             {

--- a/example/example.cfg.example
+++ b/example/example.cfg.example
@@ -1,8 +1,8 @@
 # Register your test application here: https://github.com/settings/applications/
 
 _github_oauth_config = {
-    'client_id': '',  # put your key here
-    'client_secret': '',  # put your secret here
+    'client_id': '',  # put your client id here
+    'client_secret': '',  # put your client secret here
     'authorize_url': 'https://github.com/login/oauth/authorize',
     'access_token_url': 'https://github.com/login/oauth/access_token',
     'api_base_url': 'https://api.github.com',
@@ -32,6 +32,88 @@ _my_ldap_config = {
     'ad_group_style': False,
 }
 
+_my_saml_config = {
+    # If enabled, errors are more verbose and received attributes are
+    # printed to stdout
+    # 'debug': True,
+    'sp': {
+        # this needs to match what you use when registering the SAML SP
+        'entityId': 'multipass-saml-test',
+        # these bindings usually do not need to be set manually; the URLs
+        # are auto-generated
+        # 'assertionConsumerService': {'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'},
+        # 'singleLogoutService': {'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'},
+        # depending on your security config you may need to generate a
+        # certificate and private key.
+        # you can use https://www.samltool.com/self_signed_certs.php or
+        # use `openssl` for it (which is more secure as it ensures the
+        # key never leaves your machine)
+        'x509cert': '',
+        'privateKey': '',
+        # persistent name ids are the default, but you can override it
+        # with a custom format
+        # 'NameIDFormat': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+    },
+    'idp': {
+        # This metadata is provider by your SAML IdP. You can omit (or
+        # leave empty) the whole 'idp' section in case you need SP
+        # metadata to register your app and get the IdP metadata from
+        # https://yourapp.example.com/multipass/saml/{auth-provider-name}/metadata
+        # and then fill in the IdP metadata afterwards.
+        'entityId': 'https://idp.example.com',
+        'x509cert': '',
+        'singleSignOnService': {
+            'url': 'https://idp.example.com/saml',
+            'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+        },
+        # If you do not want to perform a SAML logout when logging out
+        # from your application, you can omit this section
+        'singleLogoutService': {
+            'url': 'https://idp.example.com/saml',
+            'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+        }
+    },
+    # These advanced settings allow you to tune the SAML security options.
+    # Please see the documentation on https://github.com/onelogin/python3-saml
+    # for details on how they behave. Note that by requiring signatures,
+    # you usually need to set a cert and key on your SP config, but for
+    # testing you may want to disable all signing-related options.
+    'security': {
+        'nameIdEncrypted': False,
+        'authnRequestsSigned': True,
+        'logoutRequestSigned': True,
+        'logoutResponseSigned': True,
+        'signMetadata': True,
+        'wantMessagesSigned': True,
+        'wantAssertionsSigned': True,
+        'wantNameId' : True,
+        'wantNameIdEncrypted': False,
+        'wantAssertionsEncrypted': False,
+        'allowSingleLabelDomains': False,
+        'signatureAlgorithm': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+        'digestAlgorithm': 'http://www.w3.org/2001/04/xmlenc#sha256'
+    },
+    # You can set contact information which will be included in the SP
+    # metadata; it is up to the IdP if/how this information is used:
+    # 'contactPerson': {
+    #     'technical': {
+    #         'givenName': 'technical_name',
+    #         'emailAddress': 'technical@example.com'
+    #     },
+    #     'support': {
+    #         'givenName': 'support_name',
+    #         'emailAddress': 'support@example.com'
+    #     }
+    # },
+    # 'organization': {
+    #     'en-US': {
+    #         'name': 'sp_test',
+    #         'displayname': 'SP test',
+    #         'url': 'http://sp.example.com'
+    #     }
+    # }
+}
+
 MULTIPASS_AUTH_PROVIDERS = {
     'test_auth_provider': {
         'type': 'static',
@@ -46,12 +128,25 @@ MULTIPASS_AUTH_PROVIDERS = {
         'title': 'GitHub',
         'authlib_args': _github_oauth_config
     },
-    'sso': {
+    'my-ldap': {
+        'type': 'ldap',
+        'title': 'My Organization LDAP',
+        'ldap': _my_ldap_config,
+    },
+    'shib': {
         'type': 'shibboleth',
-        'title': 'SSO',
+        'title': 'Shibboleth SSO',
         'callback_uri': '/shibboleth/sso',
         'logout_uri': 'https://sso.example.com/logout'
-    }
+    },
+    'saml': {
+        'type': 'saml',
+        'title': 'SAML SSO',
+        'saml_config': _my_saml_config,
+        # If your IdP is ADFS you may need to enable this. For details, see
+        # https://github.com/onelogin/python-saml/pull/144
+        # 'lowercase_urlencoding': True
+    },
 }
 
 MULTIPASS_IDENTITY_PROVIDERS = {
@@ -75,6 +170,15 @@ MULTIPASS_IDENTITY_PROVIDERS = {
             'first_name': 'name'
         }
     },
+    'my-ldap': {
+        'type': 'ldap',
+        'ldap': _my_ldap_config,
+        'mapping': {
+            'name': 'givenName',
+            'email': 'mail',
+            'affiliation': 'company'
+        }
+    },
     'my_shibboleth': {
         'type': 'shibboleth',
         'mapping': {
@@ -82,12 +186,27 @@ MULTIPASS_IDENTITY_PROVIDERS = {
             'name': 'ADFS_FIRSTNAME',
             'affiliation': 'ADFS_HOMEINSTITUTE'
         }
+    },
+    'saml': {
+        'type': 'saml',
+        'title': 'SAML',
+        'mapping': {
+            'name': 'DisplayName',
+            'email': 'EmailAddress',
+            'affiliation': 'HomeInstitute',
+        },
+        # You can use a different field as the unique identifier.
+        # By default the qualified NameID from SAML is used, but in
+        # case you want to use something else, any SAML attribute can
+        # be used.
+        # 'identifier_field': 'Username'
     }
 }
 
 MULTIPASS_PROVIDER_MAP = {
     'test_auth_provider': 'test_identity_provider',
-    'sso': 'my_shibboleth',
+    'my-ldap': 'my-ldap',
+    'shib': 'my_shibboleth',
     # You can also be explicit (only needed for more complex links)
     'github': [
         {

--- a/flask_multipass/providers/saml.py
+++ b/flask_multipass/providers/saml.py
@@ -1,0 +1,199 @@
+# This file is part of Flask-Multipass.
+# Copyright (C) 2015 - 2021 CERN
+#
+# Flask-Multipass is free software; you can redistribute it
+# and/or modify it under the terms of the Revised BSD License.
+
+from flask import current_app, make_response, redirect, request, session, url_for
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from werkzeug.urls import url_parse
+
+from flask_multipass.auth import AuthProvider
+from flask_multipass.data import AuthInfo, IdentityInfo
+from flask_multipass.exceptions import AuthenticationFailed, IdentityRetrievalFailed, MultipassException
+from flask_multipass.identity import IdentityProvider
+from flask_multipass.util import login_view
+
+
+class SAMLAuthProvider(AuthProvider):
+    """Provides authentication using SAML.
+
+    The type name to instantiate this provider is *saml*.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.strip_prefix = self.settings.setdefault('strip_prefix', 'http://schemas.xmlsoap.org/claims/')
+        self.saml_acs_uri = self.settings.setdefault('saml_acs_uri', f'/multipass/saml/{self.name}/acs')
+        self.saml_sls_uri = self.settings.setdefault('saml_sls_uri', f'/multipass/saml/{self.name}/sls')
+        self.saml_metadata_uri = self.settings.setdefault('saml_metadata_uri', f'/multipass/saml/{self.name}/metadata')
+        self.saml_acs_endpoint = f'_flaskmultipass_saml_acs_{self.name}'
+        self.saml_sls_endpoint = f'_flaskmultipass_saml_sls_{self.name}'
+        self.saml_metadata_endpoint = f'_flaskmultipass_saml_metadata_{self.name}'
+        current_app.add_url_rule(self.saml_acs_uri, self.saml_acs_endpoint, self._saml_acs, methods=('GET', 'POST'))
+        current_app.add_url_rule(self.saml_sls_uri, self.saml_sls_endpoint, self._saml_sls, methods=('GET', 'POST'))
+        current_app.add_url_rule(self.saml_metadata_uri, self.saml_metadata_endpoint, self._saml_metadata)
+
+    @property
+    def saml_config(self):
+        return self.settings['saml_config']
+
+    def _prepare_flask_request(self):
+        url_data = url_parse(request.url)
+        return {
+            'https': 'on' if request.scheme == 'https' else 'off',
+            'http_host': request.host,
+            'server_port': url_data.port,
+            'script_name': request.path,
+            'get_data': request.args.copy(),
+            'post_data': request.form.copy(),
+            # enable when using ADFS as IdP, https://github.com/onelogin/python-saml/pull/144
+            'lowercase_urlencoding': self.settings.get('lowercase_urlencoding', False)
+        }
+
+    def _init_saml_auth(self):
+        config = dict(self.saml_config)
+        config.setdefault('strict', True)
+        config.setdefault('debug', False)
+        idp_config = config.setdefault('idp', {})
+        if not idp_config:
+            # dummy data so we can generate the SP metadata
+            idp_config.update({
+                'entityId': 'https://idp.example.com',
+                'singleSignOnService': {
+                    'url': 'https://idp.example.com/saml',
+                    'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+                },
+                'singleLogoutService': {
+                    'url': 'https://idp.example.com/saml',
+                    'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+                },
+                'x509cert': ''
+            })
+        config['sp'].setdefault('NameIDFormat', 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent')
+        acs_config = config['sp'].setdefault('assertionConsumerService', {})
+        acs_config.setdefault('binding', "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
+        acs_config['url'] = url_for(self.saml_acs_endpoint, _external=True)
+        slo_config = config['sp'].get('singleLogoutService')
+        if slo_config is not None:
+            slo_config.setdefault('binding', "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect")
+            slo_config['url'] = url_for(self.saml_sls_endpoint, _external=True)
+        req = self._prepare_flask_request()
+        return OneLogin_Saml2_Auth(req, config)
+
+    def _make_session_key(self, name):
+        return f'_flaskmultipass_saml_{self.name}_{name}'
+
+    def initiate_external_login(self):
+        auth = self._init_saml_auth()
+        return redirect(auth.login())
+
+    def process_logout(self, return_url):
+        auth = self._init_saml_auth()
+        if auth.get_slo_url() is None:
+            return None
+        name_id = session_index = name_id_format = name_id_nq = name_id_spnq = None
+        name_id = session.get(self._make_session_key('name_id'), None)
+        name_id_format = session.get(self._make_session_key('name_id_format'), None)
+        name_id_nq = session.get(self._make_session_key('name_id_nq'), None)
+        name_id_spnq = session.get(self._make_session_key('name_id_spnq'), None)
+        session_index = session.get(self._make_session_key('session_index'), None)
+        return redirect(auth.logout(name_id=name_id, session_index=session_index, nq=name_id_nq,
+                                    name_id_format=name_id_format, spnq=name_id_spnq,
+                                    return_to=return_url))
+
+    @login_view
+    def _saml_acs(self):
+        auth = self._init_saml_auth()
+        session_key_request_id = self._make_session_key('request_id')
+        session_key_name_id = self._make_session_key('name_id')
+        session_key_name_id_format = self._make_session_key('name_id_format')
+        session_key_name_id_nq = self._make_session_key('name_id_nq')
+        session_key_name_id_spnq = self._make_session_key('name_id_spnq')
+        session_key_session_index = self._make_session_key('session_index')
+        request_id = session.get(session_key_request_id)
+        auth.process_response(request_id=request_id)
+        errors = auth.get_errors()
+        if errors:
+            error_reason = 'SAML login failed'
+            if auth.get_settings().is_debug_active():
+                error_reason += f' ({auth.get_last_error_reason()})'
+            raise AuthenticationFailed(error_reason)
+        session.pop(session_key_request_id, None)
+        session[session_key_name_id] = saml_nameid = auth.get_nameid()
+        session[session_key_name_id_format] = auth.get_nameid_format()
+        session[session_key_name_id_nq] = saml_nameid_nq = auth.get_nameid_nq()
+        session[session_key_name_id_spnq] = saml_nameid_spnq = auth.get_nameid_spnq()
+        session[session_key_session_index] = auth.get_session_index()
+
+        attributes = auth.get_attributes()
+        if self.strip_prefix:
+            attributes = {
+                (k[len(self.strip_prefix):] if k.startswith(self.strip_prefix) else k): v
+                for k, v in attributes.items()
+            }
+        # flatten single-element lists; otherwise linking e.g. to an LDAP identity
+        # provider is not possible
+        attributes = {k: v[0] if isinstance(v, list) and len(v) == 1 else v for k, v in attributes.items()}
+        attributes['_saml_nameid'] = saml_nameid
+        attributes['_saml_nameid_qualified'] = '@'.join(x for x in [saml_nameid, saml_nameid_nq, saml_nameid_spnq]
+                                                        if x is not None)
+        if auth.get_settings().is_debug_active():
+            print(f'Login successful; received attributes: {attributes}')
+        if not attributes:
+            raise AuthenticationFailed('No valid data received', provider=self)
+        return self.multipass.handle_auth_success(AuthInfo(self, **attributes))
+
+    def _saml_sls(self):
+        auth = self._init_saml_auth()
+        session_key_logout_request_id = self._make_session_key('logout_request_id')
+        request_id = session.get(session_key_logout_request_id)
+        dscb = lambda: session.clear()  # noqa: E731
+        url = auth.process_slo(request_id=request_id, delete_session_cb=dscb)
+        errors = auth.get_errors()
+        if errors:
+            error_reason = 'SAML logout failed'
+            if auth.get_settings().is_debug_active():
+                error_reason += f' ({auth.get_last_error_reason()})'
+            raise MultipassException(error_reason)
+        if url is not None:
+            return redirect(url)
+        else:
+            return redirect(auth.redirect_to(request.form.get('RelayState', '/')))
+
+    def _saml_metadata(self):
+        auth = self._init_saml_auth()
+        settings = auth.get_settings()
+        metadata = settings.get_sp_metadata()
+        errors = settings.validate_metadata(metadata)
+
+        if errors:
+            return make_response(', '.join(errors), 500)
+        resp = make_response(metadata, 200)
+        resp.headers['Content-Type'] = 'text/xml'
+        return resp
+
+
+class SAMLIdentityProvider(IdentityProvider):
+    """Provides identity information using SAML.
+
+    The type name to instantiate this provider is *saml*.
+    """
+
+    #: If the provider supports getting identity information based from
+    #: an identifier
+    supports_get = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.id_field = self.settings.setdefault('identifier_field', '_saml_nameid_qualified')
+
+    def get_identity_from_auth(self, auth_info):
+        identifier = auth_info.data.get(self.id_field)
+        if isinstance(identifier, list):
+            if len(identifier) != 1:
+                raise IdentityRetrievalFailed('Identifier has multiple elements', provider=self)
+            identifier = identifier[0]
+        if not identifier:
+            raise IdentityRetrievalFailed('Identifier missing in saml response', provider=self)
+        return IdentityInfo(self, identifier=identifier, **auth_info.data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ authlib =
 ldap =
     flask-wtf
     python-ldap>=3.3.1,<4.0
+saml =
+    python3-saml>=1.10.1,<1.11
 sqlalchemy =
     sqlalchemy
     flask-wtf
@@ -51,10 +53,12 @@ include =
 flask_multipass.auth_providers =
     ldap = flask_multipass.providers.ldap:LDAPAuthProvider
     authlib = flask_multipass.providers.authlib:AuthlibAuthProvider
+    saml = flask_multipass.providers.saml:SAMLAuthProvider
     shibboleth = flask_multipass.providers.shibboleth:ShibbolethAuthProvider
     static = flask_multipass.providers.static:StaticAuthProvider
 flask_multipass.identity_providers =
     ldap = flask_multipass.providers.ldap:LDAPIdentityProvider
     authlib = flask_multipass.providers.authlib:AuthlibIdentityProvider
+    saml = flask_multipass.providers.saml:SAMLIdentityProvider
     shibboleth = flask_multipass.providers.shibboleth:ShibbolethIdentityProvider
     static = flask_multipass.providers.static:StaticIdentityProvider


### PR DESCRIPTION
Tested with Keycloak at CERN and Okta, but since SAML is standardized it should work with ADFS etc. as well.

Also cleaned up the example configs a bit.