### PR TITLE
Remove upper authlib pin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.4.9
+-------------
+
+- Support authlib 1.1 (remove upper version pin)
+
 Version 0.4.8
 -------------
 

--- a/flask_multipass/__init__.py
+++ b/flask_multipass/__init__.py
@@ -13,7 +13,7 @@ from .group import Group
 from .identity import IdentityProvider
 
 
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 __all__ = ('Multipass', 'AuthProvider', 'IdentityProvider', 'AuthInfo', 'IdentityInfo', 'Group', 'MultipassException',
            'AuthenticationFailed', 'IdentityRetrievalFailed', 'GroupRetrievalFailed', 'NoSuchUser',
            'InvalidCredentials')

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ dev =
     pytest-cov
     pytest-mock
 authlib =
-    authlib>=0.14.1,<1.1
+    authlib>=0.14.1
     requests
 ldap =
     flask-wtf


### PR DESCRIPTION
They aren't making weird breaking changes anymore, and pinning max versions in libraries is generally considered a bad idea.