### PR TITLE
Fix entry point loading on Python 3.8 and 3.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.5.1
+-------------
+
+- Fix compatibility with Python 3.8 and 3.9
+
 Version 0.5
 -----------
 

--- a/flask_multipass/__init__.py
+++ b/flask_multipass/__init__.py
@@ -13,7 +13,7 @@ from .group import Group
 from .identity import IdentityProvider
 
 
-__version__ = '0.5'
+__version__ = '0.5.1'
 __all__ = ('Multipass', 'AuthProvider', 'IdentityProvider', 'AuthInfo', 'IdentityInfo', 'Group', 'MultipassException',
            'AuthenticationFailed', 'IdentityRetrievalFailed', 'GroupRetrievalFailed', 'NoSuchUser',
            'InvalidCredentials')

--- a/flask_multipass/util.py
+++ b/flask_multipass/util.py
@@ -4,6 +4,7 @@
 # Flask-Multipass is free software; you can redistribute it
 # and/or modify it under the terms of the Revised BSD License.
 
+import sys
 from functools import wraps
 from importlib.metadata import entry_points as importlib_entry_points
 from inspect import getmro, isclass
@@ -143,14 +144,17 @@ def resolve_provider_type(base, type_, registry=None):
     if registry is not None and type_ in registry:
         cls = registry[type_]
     else:
-        entry_points = importlib_entry_points(group=base._entry_point, name=type_)
+        if sys.version_info < (3, 10):
+            entry_points = {ep for ep in importlib_entry_points().get(base._entry_point, []) if ep.name == type_}
+        else:
+            entry_points = importlib_entry_points(group=base._entry_point, name=type_)
         if not entry_points:
             raise ValueError('Unknown type: ' + type_)
         elif len(entry_points) != 1:
             # TODO: remove the getattr check after dropping python 3.8
             defs = ', '.join(getattr(ep, 'module', ep.value) for ep in entry_points)
             raise RuntimeError(f'Type {type_} is not unique. Defined in {defs}')
-        entry_point = entry_points[0]
+        entry_point = list(entry_points)[0]
         cls = entry_point.load()
     if not issubclass(cls, base):
         raise TypeError(f'Found a class {cls} which is not a subclass of {base}')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -218,3 +218,12 @@ def test_handle_auth_error_with_redirect(mocker):
         multipass.handle_auth_error(AuthenticationFailed(), redirect_to_login=True)
         assert flash.called
         redirect.assert_called_with(app.config['MULTIPASS_LOGIN_URLS'][0])
+
+
+def test_load_providers_from_entrypoints():
+    app = Flask('test')
+    app.config['SECRET_KEY'] = 'testing'
+    app.config['MULTIPASS_AUTH_PROVIDERS'] = {'test': {'type': 'static'}}
+    app.config['MULTIPASS_IDENTITY_PROVIDERS'] = {'test': {'type': 'static'}}
+    app.config['MULTIPASS_PROVIDER_MAP'] = {'test': 'test'}
+    Multipass(app)


### PR DESCRIPTION
- `importlib.metadata` is a mess between Python versions
- my mocking of entry point loading was pretty broken and not matching the standard structure
- there were no tests that actually used the real un-mocked entry point loading (which is how this bug slipped in to begin with)

fixes #71