### PR TITLE
Skip LDAP users with no uid attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 0.5.4
+-------------
+
+- Skip LDAP users that do not have the specified ``uid`` attribute set instead
+  of failing with an error
+
 Version 0.5.3
 -------------
 

--- a/flask_multipass/__init__.py
+++ b/flask_multipass/__init__.py
@@ -13,7 +13,7 @@ from .group import Group
 from .identity import IdentityProvider
 
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 __all__ = ('Multipass', 'AuthProvider', 'IdentityProvider', 'AuthInfo', 'IdentityInfo', 'Group', 'MultipassException',
            'AuthenticationFailed', 'IdentityRetrievalFailed', 'GroupRetrievalFailed', 'NoSuchUser',
            'InvalidCredentials')

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -202,7 +202,12 @@ class LDAPIdentityProvider(LDAPProviderMixin, IdentityProvider):
                 raise IdentityRetrievalFailed("Unable to generate search filter from criteria", provider=self)
             for _, user_data in self._search_users(search_filter):
                 user_data = to_unicode(user_data)
-                yield IdentityInfo(self, identifier=user_data[self.ldap_settings['uid']][0], **user_data)
+                try:
+                    identifier = user_data[self.ldap_settings['uid']][0]
+                except KeyError:
+                    # user does not have an identifier -> skip it
+                    continue
+                yield IdentityInfo(self, identifier=identifier, **user_data)
 
     def get_identity_groups(self, identifier):
         groups = set()


### PR DESCRIPTION
Same bug as #76 but when searching users instead of retrieving group members.