### PR TITLE
Fix open redirect with backslash URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 0.5.6
+-------------
+
+- Reject invalid ``next`` URLs with backslashes that could be used to trick browsers into
+  redirecting to an otherwise disallowed host when doing client-side redirects
+
 Version 0.5.5
 -------------
 

--- a/flask_multipass/core.py
+++ b/flask_multipass/core.py
@@ -135,8 +135,9 @@ class Multipass:
         a whitelist of trusted hosts to avoid creating an open redirector.
         """
         url_info = urlsplit(url)
-        if (url_info.scheme and url_info.scheme not in {'http', 'https'})\
-            or (url_info.scheme in {'http', 'https'} and not url_info.netloc):
+        if url_info.scheme and url_info.scheme not in {'http', 'https'}:
+            return False
+        if url_info.scheme in {'http', 'https'} and not url_info.netloc:
             return False
         return not url_info.netloc or url_info.netloc == request.host
 

--- a/flask_multipass/core.py
+++ b/flask_multipass/core.py
@@ -134,10 +134,13 @@ class Multipass:
         If you override this and want to allow more hosts, make sure to use
         a whitelist of trusted hosts to avoid creating an open redirector.
         """
-        url_info = urlsplit(url)
+        # Browsers treat backslashes like forward slashes, while urllib doesn't.
+        # Since we just want to validate scheme and netloc here, we normalize
+        # slashes to those recognized by urllib.
+        url_info = urlsplit(url.replace('\\', '/'))
         if url_info.scheme and url_info.scheme not in {'http', 'https'}:
             return False
-        if url_info.scheme in {'http', 'https'} and not url_info.netloc:
+        if url_info.scheme and not url_info.netloc:
             return False
         return not url_info.netloc or url_info.netloc == request.host
 

--- a/flask_multipass/core.py
+++ b/flask_multipass/core.py
@@ -135,7 +135,8 @@ class Multipass:
         a whitelist of trusted hosts to avoid creating an open redirector.
         """
         url_info = urlsplit(url)
-        if url_info.scheme and url_info.scheme not in {'http', 'https'}:
+        if (url_info.scheme and url_info.scheme not in {'http', 'https'})\
+            or (url_info.scheme in {'http', 'https'} and not url_info.netloc):
             return False
         return not url_info.netloc or url_info.netloc == request.host
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'Flask-Multipass'
-version = '0.5.5'
+version = '0.5.6'
 description = 'A pluggable solution for multi-backend authentication with Flask'
 readme = 'README.rst'
 license = 'BSD-3-Clause'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -161,10 +161,10 @@ def test_next_url_invalid():
     ('//evil.com:80', False),
     ('http://evil.com', False),
     ('https://evil.com', False),
-    ('http:\\\\evil.com', False),
-    ('http:\\evil.com', False),
-    ('https:\\\\evil.com', False),
-    ('https:\\evil.com', False),
+    (r'http:\\evil.com', False),
+    (r'http:\evil.com', False),
+    (r'https:\\evil.com', False),
+    (r'https:\evil.com', False),
     ('javascript:alert("eeeeeeeevil")', False),
 ))
 def test_validate_next_url(url, valid):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -161,6 +161,10 @@ def test_next_url_invalid():
     ('//evil.com:80', False),
     ('http://evil.com', False),
     ('https://evil.com', False),
+    ('http:\\\\evil.com', False),
+    ('http:\\evil.com', False),
+    ('https:\\\\evil.com', False),
+    ('https:\\evil.com', False),
     ('javascript:alert("eeeeeeeevil")', False),
 ))
 def test_validate_next_url(url, valid):


### PR DESCRIPTION
The goal of this PR is to disallow open redirect for URLs formed with backslashes.
Example:
- https://\<indico-base-url\>/register/?next=https:\\\\evil.com
- https://\<indico-base-url\>/register/?next=https:\evil.com