### PR TITLE
Provide details for IdentityRetrievalFailed exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.6
 - Remove upper version pins of dependencies
 - Support friendly names for SAML assertions (set `'saml_friendly_names': True`
   in the auth provider settings)
+- Include more verbose authentication data in ``IdentityRetrievalFailed`` exception details
 
 Version 0.5.6
 -------------

--- a/flask_multipass/providers/authlib.py
+++ b/flask_multipass/providers/authlib.py
@@ -174,5 +174,5 @@ class AuthlibIdentityProvider(IdentityProvider):
         identifier = auth_info.data.get(self.id_field)
         if not identifier:
             raise IdentityRetrievalFailed(f'Identifier ({self.id_field}) missing in authlib response',
-                                          provider=self)
+                                          details=auth_info.data, provider=self)
         return IdentityInfo(self, identifier=identifier, **auth_info.data)

--- a/flask_multipass/providers/saml.py
+++ b/flask_multipass/providers/saml.py
@@ -191,8 +191,10 @@ class SAMLIdentityProvider(IdentityProvider):
         identifier = auth_info.data.get(self.id_field)
         if isinstance(identifier, list):
             if len(identifier) != 1:
-                raise IdentityRetrievalFailed('Identifier has multiple elements', provider=self)
+                raise IdentityRetrievalFailed('Identifier has multiple elements',
+                                              details=identifier, provider=self)
             identifier = identifier[0]
         if not identifier:
-            raise IdentityRetrievalFailed('Identifier missing in saml response', provider=self)
+            raise IdentityRetrievalFailed('Identifier missing in saml response',
+                                          details=auth_info.data, provider=self)
         return IdentityInfo(self, identifier=identifier, **auth_info.data)

--- a/flask_multipass/providers/shibboleth.py
+++ b/flask_multipass/providers/shibboleth.py
@@ -86,5 +86,6 @@ class ShibbolethIdentityProvider(IdentityProvider):
     def get_identity_from_auth(self, auth_info):
         identifier = auth_info.data.get(self.id_field)
         if not identifier:
-            raise IdentityRetrievalFailed('Identifier missing in shibboleth response', provider=self)
+            raise IdentityRetrievalFailed('Identifier missing in shibboleth response',
+                                          details=auth_info.data, provider=self)
         return IdentityInfo(self, identifier=identifier, **auth_info.data)


### PR DESCRIPTION
This PR is about to improve how `IdentityRetrievalFailed` exception is raised. Adding details (information we got back from the provider) to the exception helps identifying the user having authentication issue. We ran into this issue using `authlib` but I updated the other providers, too.