### PR TITLE
Add client_id to logout params

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.7
 -----------
 
 - Support multiple id fields in SAML identity provider
+- Include ``client_id`` in authlib logout URL since some OIDC providers mayrequire this
 
 Version 0.6
 -----------

--- a/flask_multipass/providers/authlib.py
+++ b/flask_multipass/providers/authlib.py
@@ -109,7 +109,8 @@ class AuthlibAuthProvider(AuthProvider):
             logout_uri = self.authlib_client.load_server_metadata().get('end_session_endpoint')
         if logout_uri:
             return_url = urljoin(request.url_root, return_url)
-            query = urlencode({'post_logout_redirect_uri': return_url})
+            client_id = self.authlib_settings['client_id']
+            query = urlencode({'post_logout_redirect_uri': return_url, 'client_id': client_id})
             return redirect(logout_uri + '?' + query)
 
     @login_view


### PR DESCRIPTION
Fixes an error on keycloak ( there either `client_id` or `id_token_hint` is required)

Fixes: #62