### PR TITLE
saml: Support multiple id fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.7
+-----------
+
+- Support multiple id fields in SAML identity provider
+
 Version 0.6
 -----------
 

--- a/flask_multipass/providers/saml.py
+++ b/flask_multipass/providers/saml.py
@@ -188,13 +188,20 @@ class SAMLIdentityProvider(IdentityProvider):
         self.id_field = self.settings.setdefault('identifier_field', '_saml_nameid_qualified')
 
     def get_identity_from_auth(self, auth_info):
-        identifier = auth_info.data.get(self.id_field)
-        if isinstance(identifier, list):
-            if len(identifier) != 1:
-                raise IdentityRetrievalFailed('Identifier has multiple elements',
-                                              details=identifier, provider=self)
-            identifier = identifier[0]
-        if not identifier:
-            raise IdentityRetrievalFailed('Identifier missing in saml response',
-                                          details=auth_info.data, provider=self)
-        return IdentityInfo(self, identifier=identifier, **auth_info.data)
+        id_fields = [self.id_field] if isinstance(self.id_field, str) else self.id_field
+        valid_identifier = None
+        for key in id_fields:
+            identifier = auth_info.data.get(key)
+            if not identifier:
+                continue
+            if isinstance(identifier, list):
+                if len(identifier) != 1:
+                    raise IdentityRetrievalFailed('Identifier has multiple elements', details=identifier, provider=self)
+                valid_identifier = identifier[0]
+                break
+            else:
+                valid_identifier = identifier
+                break
+        if not valid_identifier:
+            raise IdentityRetrievalFailed('Identifier missing in saml response', details=auth_info.data, provider=self)
+        return IdentityInfo(self, identifier=valid_identifier, **auth_info.data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'Flask-Multipass'
-version = '0.6'
+version = '0.7'
 description = 'A pluggable solution for multi-backend authentication with Flask'
 readme = 'README.rst'
 license = 'BSD-3-Clause'


### PR DESCRIPTION
This can be useful when using federations like eduGain where you may want to use a particular field by default, but fall back to the default SAML NameID in case the other field does not exist.