### PR TITLE
Fail silently on AD group with no objectSid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.9
 
 - Include the username in the ``identifier`` attribute of the ``NoSuchUser``
   exception so applications can apply e.g. per-username rate limiting
+- Fail silently when there's no ``objectSid`` for an AD-style LDAP group
 
 Version 0.8
 -----------

--- a/flask_multipass/providers/ldap/providers.py
+++ b/flask_multipass/providers/ldap/providers.py
@@ -142,7 +142,7 @@ class LDAPGroup(Group):
                 return False
             if self.ldap_settings['ad_group_style']:
                 _group_dn, group_data = get_group_by_id(self.name, attributes=['objectSid'])
-                group_sids = group_data.get('objectSid')
+                group_sids = group_data.get('objectSid', [])
                 token_groups = get_token_groups_from_user_dn(user_dn)
                 return any(group_sid in token_groups for group_sid in group_sids)
             else:


### PR DESCRIPTION
No idea when exactly this happens, but a user on the Indico forum had this problem,
and this change fixed it for them:

https://talk.getindico.io/t/calendar-export-of-a-whole-category-with-some-protected-events/3970/3

The new logic is also more appropriate since `.get()` with the `None` default makes no sense when iterating over its return value afterwards.